### PR TITLE
Argument handling improvement

### DIFF
--- a/lec.cc
+++ b/lec.cc
@@ -506,6 +506,7 @@ int is_file (char *arg)
   else
   {
     opening_test = 0; // this is a file
+    fclose (file);
   }
 
   return opening_test;


### PR DESCRIPTION
I first thought I'd post an issue, but since it was pretty simple, I solved it myself.

Despite a long list of conditions, not all cases were previously handled correctly. For example, if the command was just edcre -s 15 without the track bin file, it was interpreting 15 as the track name and complained it couldn't be found.

The "rules" are these:
* the track should be the last argument
* -v, -t, or -k should not be the last argument
* -s should be followed by a minimum of two arguments, not just one
* there may be up to seven arguments, not just six

So I tried to make to code more efficient and removed some code duplication. Error messages like the one for -s may also be added later for -v, -t, -k.

One downside though: you can not use tracks that are also named -v, -t, or -k...