### PR TITLE
Update Makefile for cleaner MacOS support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,24 +65,6 @@ ifeq ($(strip $(BUILD_LIB)),)
 	$(error Error: The $$BUILD_LIB variable is not set in variables.mk but is required)
 endif
 
-# Check compiler.
-
-ifeq ($(strip $(COMPILER)),)
-	$(error Error: The $$COMPILER variable is not set in variables.mk but is required)
-endif
-
-ifeq ($(strip $(LINUX_COMPILER)),)
-	$(error Error: The $$LINUX_COMPILER variable is not set in variables.mk but is required)
-endif
-
-ifeq ($(strip $(WINDOWS_I686_COMPILER)),)
-	$(error Error: The $$WINDOWS_I686_COMPILER variable is not set in variables.mk but is required)
-endif
-
-ifeq ($(strip $(WINDOWS_X86_64_COMPILER)),)
-	$(error Error: The $$WINDOWS_X86_64_COMPILER variable is not set in variables.mk but is required)
-endif
-
 # Check compiler flags.
 
 ifeq ($(strip $(COMPILER_FLAGS)),)
@@ -135,24 +117,24 @@ endif
 
 # OPTIONAL, not default: Build C libraries to be used by the target executable. To enable this, you must replace `library-file*` with the actual name of the library, and you must set `BUILD_LIB=YES` in `variables.mk`.
 ifeq ("$(BUILD_LIB)","YES")
-	$(COMPILER) $(COMPILER_FLAGS_LIB) -c library-files-dir/library-file.c -o $(BUILD_DIR)/library-file-object.o
+	$(CXX) $(COMPILER_FLAGS_LIB) -c library-files-dir/library-file.c -o $(BUILD_DIR)/library-file-object.o
 	$(AR) rcs $(BUILD_DIR)/library-file-archive.a $(BUILD_DIR)/library-file-object.o
 
 ifeq ($(strip $(EXECUTABLE_NAME)),)
-	$(COMPILER) $(COMPILER_FLAGS) $(SOURCE_FILES) -L./$(BUILD_DIR) -llibrary-file -o $(BUILD_DIR)/$(PROGRAM)
+	$(CXX) $(COMPILER_FLAGS) $(SOURCE_FILES) -L./$(BUILD_DIR) -llibrary-file -o $(BUILD_DIR)/$(PROGRAM)
 	$(STRIP) $(BUILD_DIR)/$(PROGRAM)
 else
-	$(COMPILER) $(COMPILER_FLAGS) $(SOURCE_FILES) -L./$(BUILD_DIR) -llibrary-file -o $(BUILD_DIR)/$(EXECUTABLE_NAME)
+	$(CXX) $(COMPILER_FLAGS) $(SOURCE_FILES) -L./$(BUILD_DIR) -llibrary-file -o $(BUILD_DIR)/$(EXECUTABLE_NAME)
 	$(STRIP) $(BUILD_DIR)/$(EXECUTABLE_NAME)
 endif
 
 else # Default: Does not build any C libraries. `BUILD_LIB=NO` in `variables.mk`.
 
 ifeq ($(strip $(EXECUTABLE_NAME)),)
-	$(COMPILER) $(COMPILER_FLAGS) $(SOURCE_FILES) -o $(BUILD_DIR)/$(PROGRAM)
+	$(CXX) $(COMPILER_FLAGS) $(SOURCE_FILES) -o $(BUILD_DIR)/$(PROGRAM)
 	$(STRIP) $(BUILD_DIR)/$(PROGRAM)
 else
-	$(COMPILER) $(COMPILER_FLAGS) $(SOURCE_FILES) -o $(BUILD_DIR)/$(EXECUTABLE_NAME)
+	$(CXX) $(COMPILER_FLAGS) $(SOURCE_FILES) -o $(BUILD_DIR)/$(EXECUTABLE_NAME)
 	$(STRIP) $(BUILD_DIR)/$(EXECUTABLE_NAME)
 endif
 
@@ -187,6 +169,10 @@ linux-i386: clean
 .PHONY: linux-x86_64
 linux-x86_64: clean
 	make $(PROGRAM) EXECUTABLE_NAME='$(PROGRAM).x86_64'
+
+.PHONY: macos
+macos: clean
+	make $(PROGRAM) EXECUTABLE_NAME='$(PROGRAM).macos'
 
 .PHONY: windows-i686
 windows-i686: clean
@@ -225,6 +211,14 @@ ifeq ($(strip $(LINUX_SPECIFIC_RELEASE_FILES)),)
 	make release PLATFORM='$(LINUX_X86_64_RELEASE_NAME_SUFFIX)' EXECUTABLE_NAME='$(PROGRAM).x86_64'
 else
 	make release PLATFORM='$(LINUX_X86_64_RELEASE_NAME_SUFFIX)' RELEASE_FILES='$(LINUX_SPECIFIC_RELEASE_FILES) $(RELEASE_FILES)' EXECUTABLE_NAME='$(PROGRAM).x86_64'
+endif
+
+.PHONY: macos-release
+macos-release: macos
+ifeq ($(strip $(MACOS_SPECIFIC_RELEASE_FILES)),)
+	make release PLATFORM='$(MACOS_RELEASE_NAME_SUFFIX)' EXECUTABLE_NAME='$(PROGRAM).macos'
+else
+	make release PLATFORM='$(MACOS_RELEASE_NAME_SUFFIX)' RELEASE_FILES='$(MACOS_SPECIFIC_RELEASE_FILES) $(RELEASE_FILES)' EXECUTABLE_NAME='$(PROGRAM).macos'
 endif
 
 .PHONY: windows-i686-release

--- a/build.md
+++ b/build.md
@@ -1,9 +1,9 @@
 
 # Building From Source
 
-In the source directory, you may execute any of the following:
+This software is built with the [EZRE](https://github.com/alex-free/ezre) build system. In the source directory, you may execute any of the following:
 
-`make deps-apt` - installs the build dependencies required to compile the program.
+`make deps` - installs the build dependencies required to compile the program on Linux x86_64 Linux distributions with either the `dnf` or `apt` package manager.
 
 `make` - creates an executable for x86_64 Linux.
 
@@ -11,28 +11,30 @@ In the source directory, you may execute any of the following:
 
 `make clean-build` - deletes the generated build directory in it's entirety.
 
-`make all` - **generate all of the following:**
+`make all` - **generates all of the following:**
 
 ### For Windows 95 OSR 2.5 and above, Pentium CPU minimum (32 bit)
 
-*   Windows i686 static executable file
-*   Portable Windows i386 release .zip file
+*   Windows i686 static executable file.
+*   Portable Windows i386 release .zip file.
 
 ### For Windows x86_64 (64 bit)
 
-*   Windows x86_64 static executable file
-*   Portable Windows x86_64 release .zip file
+*   Windows x86_64 static executable file.
+*   Portable Windows x86_64 release .zip file.
 
 ### For Linux 3.2.0 and above, 386 CPU minimum (32 bit)
 
-*   Linux i386 static executable file
-*   Portable Linux i386 release .zip file
-*   Linux i386 release .deb file
+*   Linux i386 static executable file.
+*   Portable Linux i386 release .zip file.
+*   Linux i386 release .deb file for Debian based Linux distributions.
+*   Linux i386 release .rpm file for Redhat based Linux distributions.
 
 ### For Linux 3.2.0 and above, x86_64 (64 bit)
 
-*   Linux x86_64 static executable file
-*   Portable Linux x86_64 release .zip file
-*   Linux x86_64 release .deb file
+*   Linux x86_64 static executable file.
+*   Portable Linux x86_64 release .zip file.
+*   Linux x86_64 release .deb file for Debian based Linux distributions.
+*   Linux x86_64 release .rpm file for Redhat based Linux distributions.
 
-All output is found in the build directory created in the source directory.
+All output is found in the `build` directory created in the source directory.

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,32 @@
-# Changelog
+# [EDCRE: EDC/ECC Regenerator For BIN+CUE CD Disc Images](readme.md) -> Changelog
 
-## Downloads
+### Version 1.0.8 (7/31/2024)
+
+Changes:
+
+*  Improved argument handling (thanks [@jonblau](https://github.com/jonblau) for the [first implementation](https://github.com/alex-free/edcre/pull/2)!).
+
+*  Scan progress is now displayed as a percentage in real time.
+
+*   Optimized and cleaned up code.
+
+*   LBA is provided if not using the `-k` argument in ouput information. Sector number (starting from sector 0 at the begining of the input file) is always provided, even with `-k`.
+
+*   Number of mode 1, mode 2 form 1, and mode 2 form 2 sectors scanned is displayed in the scan report.
+
+----------------------------------------------------
+
+*	[edcre-v1.0.8-windows-i686-static.zip](https://github.com/alex-free/edcre/releases/download/v1.0.8/edcre-v1.0.8-windows-i686-static.zip) _Portable Release For Windows 95 OSR 2.5 and above, Pentium CPU minimum (32 bit)_
+
+*	[edcre-v1.0.8-windows-x86\_64-static.zip](https://github.com/alex-free/edcre/releases/download/v1.0.8/edcre-v1.0.8-windows-x86_64-static.zip) _Portable Release For x86_64 Windows (64 bit)_
+
+*	[edcre-v1.0.8-linux-i386-static.zip](https://github.com/alex-free/edcre/releases/download/v1.0.8/edcre-v1.0.8-linux-i386-static.zip) _Portable Release For Linux 3.2.0 and above, 386 CPU minimum (32 bit)_
+
+*	[edcre-v1.0.8-linux-i386-static.deb](https://github.com/alex-free/edcre/releases/download/v1.0.8/edcre-v1.0.8-linux-i386-static.deb) _Deb package file For Linux 3.2.0 and above, 386 CPU minimum (32 bit)_
+
+*	[edcre-v1.0.8-linux-x86\_64-static.zip](https://github.com/alex-free/edcre/releases/download/v1.0.8/edcre-v1.0.8-linux-x86_64-static.zip) _Portable Release For x86\_64 Linux 3.2.0 and above (64 bit)_
+
+*	[edcre-v1.0.8-linux-x86\_64-static.deb](https://github.com/alex-free/edcre/releases/download/v1.0.8/edcre-v1.0.8-linux-x86_64-static.deb) _Deb package file for x86_64 Linux 3.2.0 and above (64 bit)_
 
 ## Version 1.0.7 (7/4/2024)
 

--- a/control-i386
+++ b/control-i386
@@ -1,5 +1,5 @@
 Package: edcre
-Version: 1.0.8
+Version: 1.0.9
 Maintainer: Alex Free
 Architecture: i386
 Homepage: https://alex-free.github.io/edcre

--- a/control-x86_64
+++ b/control-x86_64
@@ -1,5 +1,5 @@
 Package: edcre
-Version: 1.0.8
+Version: 1.0.9
 Maintainer: Alex Free
 Architecture: amd64
 Homepage: https://alex-free.github.io/edcre

--- a/ezre.spec
+++ b/ezre.spec
@@ -1,0 +1,17 @@
+Name:           edcre
+Version:        1.0.9
+Summary:        Your description.
+Release:        1%{?dist}
+License:        GNU GPLv2
+URL:            https://alex-free.github.io/ezre
+Packager:       Alex Free
+
+%description
+EDC/ECC regenerator for edited CD images.
+
+%install
+mkdir -p %{buildroot}/usr/bin
+cp %{_sourcedir}/edcre %{buildroot}/usr/bin/
+
+%files
+/usr/bin/edcre

--- a/readme.md
+++ b/readme.md
@@ -12,38 +12,40 @@ An advanced solution to detect and or update EDC/ECC data to match any edits don
 * [PSX EDC Protection Workaround With EDCRE](#psx-edc-protection-workaround-with-edcre)
 * [Usage](#usage)
 * [Building](build.md)
-* [License](#license)
+* [License](license.md)
 * [Credits](#credits)
 
 ## Downloads
 
-### Version 1.0.8 (7/31/2024)
+### Version 1.0.9 (2/11/2025)
 
 Changes:
 
-*  Improved argument handling (thanks [@jonblau](https://github.com/jonblau) for the [first implementation](https://github.com/alex-free/edcre/pull/2)!).
+* Fixed Windows builds, closing [issue #3](https://github.com/alex-free/edcre/issues/3).
 
-*  Scan progress is now displayed as a percentage in real time.
+* For all operating systems, if test only mode is given (`-t`) then the input file is opened as read only, which is more correct. Otherwise it is open as read write so that EDC/ECC can be updated if needed.
 
-*   Optimized and cleaned up code.
+* The verbose (`-v`) argument now displays which sectors/lbas are invalid, if any are. Without specifying verbose mode, it is no longer printed by default which exact sectors need updating of EDC/ECC and you just get the scan report at the end saying how many were. This is more consistent with how verbose mode already only displays which sectors/lbas were fixed, rather then just a sum of how many in the scan report.
 
-*   LBA is provided if not using the `-k` argument in ouput information. Sector number (starting from sector 0 at the begining of the input file) is always provided, even with `-k`.
-
-*   Number of mode 1, mode 2 form 1, and mode 2 form 2 sectors scanned is displayed in the scan report.
+* Updated EzRe build system to v1.0.3. RPM package files are now generated for i386 and x86_64 Linux.
 
 ----------------------------------------------------
 
-*	[edcre-v1.0.8-windows-i686-static.zip](https://github.com/alex-free/edcre/releases/download/v1.0.8/edcre-v1.0.8-windows-i686-static.zip) _Portable Release For Windows 95 OSR 2.5 and above, Pentium CPU minimum (32 bit)_
+*	[edcre-v1.0.9-windows-i686-static.zip](https://github.com/alex-free/edcre/releases/download/v1.0.9/edcre-v1.0.9-windows-i686-static.zip) _Portable Release For Windows 95 OSR 2.5 and above, Pentium CPU minimum (32 bit)_
 
-*	[edcre-v1.0.8-windows-x86\_64-static.zip](https://github.com/alex-free/edcre/releases/download/v1.0.8/edcre-v1.0.8-windows-x86_64-static.zip) _Portable Release For x86_64 Windows (64 bit)_
+*	[edcre-v1.0.9-windows-x86\_64-static.zip](https://github.com/alex-free/edcre/releases/download/v1.0.9/edcre-v1.0.9-windows-x86_64-static.zip) _Portable Release For x86_64 Windows (64 bit)_
 
-*	[edcre-v1.0.8-linux-i386-static.zip](https://github.com/alex-free/edcre/releases/download/v1.0.8/edcre-v1.0.8-linux-i386-static.zip) _Portable Release For Linux 3.2.0 and above, 386 CPU minimum (32 bit)_
+*	[edcre-v1.0.9-linux-i386-static.zip](https://github.com/alex-free/edcre/releases/download/v1.0.9/edcre-v1.0.9-linux-i386-static.zip) _Portable Release For Linux 3.2.0 and above, 386 CPU minimum (32 bit)_
 
-*	[edcre-v1.0.8-linux-i386-static.deb](https://github.com/alex-free/edcre/releases/download/v1.0.8/edcre-v1.0.8-linux-i386-static.deb) _Deb package file For Linux 3.2.0 and above, 386 CPU minimum (32 bit)_
+*	[edcre-v1.0.9-linux-i386-static.deb](https://github.com/alex-free/edcre/releases/download/v1.0.9/edcre-v1.0.9-linux-i386-static.deb) _Deb package file For Linux 3.2.0 and above, 386 CPU minimum (32 bit)_
 
-*	[edcre-v1.0.8-linux-x86\_64-static.zip](https://github.com/alex-free/edcre/releases/download/v1.0.8/edcre-v1.0.8-linux-x86_64-static.zip) _Portable Release For x86\_64 Linux 3.2.0 and above (64 bit)_
+*	[edcre-1.0.9-1.fc41.i386.rpm](https://github.com/alex-free/edcre/releases/download/v1.0.9/edcre-1.0.9-1.fc41.i386.rpm) _RPM package file For i386 Linux 3.2.0 and above (32 bit)_
 
-*	[edcre-v1.0.8-linux-x86\_64-static.deb](https://github.com/alex-free/edcre/releases/download/v1.0.8/edcre-v1.0.8-linux-x86_64-static.deb) _Deb package file for x86_64 Linux 3.2.0 and above (64 bit)_
+*	[edcre-v1.0.9-linux-x86\_64-static.zip](https://github.com/alex-free/edcre/releases/download/v1.0.9/edcre-v1.0.9-linux-x86_64-static.zip) _Portable Release For x86\_64 Linux 3.2.0 and above (64 bit)_
+
+*	[edcre-v1.0.9-linux-x86\_64-static.deb](https://github.com/alex-free/edcre/releases/download/v1.0.9/edcre-v1.0.9-linux-x86_64-static.deb) _Deb package file for x86_64 Linux 3.2.0 and above (64 bit)_
+
+*	[edcre-1.0.9-1.fc41.x86_64.rpm](https://github.com/alex-free/edcre/releases/download/v1.0.9/edcre-1.0.9-1.fc41.x86_64.rpm) _RPM package file For x86_64 Linux 3.2.0 and above (64 bit)_
 
 ----------------------------------------------------
 
@@ -51,15 +53,23 @@ Changes:
 
 ## What Is EDC/ECC Data?
 
-EDC is a special checksum that verifies the integrity of the user data portion of a sector in a data track. If during a sector read the EDC does not match the data read by the CD drive, ECC data then provides a way to correct the data to what was expected in most cases. If a significant amount of the sector is unreadable or modified this may not be correctable with ECC data, but in many common cases (i.e. slightly scratched discs) it does work quite well and provides much more reliability and resilience for data CD reading. 
+EDC (Error Detection Code) is a checksum that verifies the integrity of the user data portion of a sector in a data track. If during a sector read the EDC does not match the data read by the CD drive, ECC (Error Correction Code) data then provides a way to correct the data to what was expected in most cases. 
 
-When you edit a data track in a CD image, the original EDC and ECC will remain untouched causing it to mismatch the new contents of the user data in any modified sectors, causing any changes to not take effect or invalidate the disc image when it is burned to a disc and used on real hardware. Usually this isn't a problem however since almost all CD burning software writes updated EDC/ECC to burned discs, and most emulators ignore the EDC/ECC data in sectors by design. [IMGBurn](https://www.imgburn.com/) always writes updated EDC/ECC data, and there isn't a way to disable that behavior. [CDRDAO](https://github.com/cdrdao/cdrdao) always writes updated EDC/ECC data when using the default `generic-mmc` driver. It is possible however specify the `generic-mmc-raw` be used instead which **does not modify EDC/ECC data and leaves it as is**. [CloneCD](https://www.redfox.bz/en/clonecd.html) always writes updated EDC/ECC data **unless you use the RAW writing mode**. Writing updated EDC data to disc is usually what you want, that way the correct matching EDC/ECC data correlates to any modification to the user data of sectors found in a disc image. 
+If a significant amount of the sector is unreadable (due to scratches and or drive issues), or a significant amount of the user data was modified without updating the EDC/ECC as well, the system falls apart but it does work quite well and provides much more reliability and resilience for data CD reading. 
 
-But what if you want to edit user data of sectors in a data track of a CD disc image and then write it raw? That is exactly what I want to do, as it defeats the EDC-based anti-piracy protection measure found in almost all of the [Dance Dance Revolution PSX games](https://alex-free.github.io/aprip#edc).
+When you edit a data track in a CD image (using a patcher, hex editor, etc.), the original EDC and ECC will remain untouched (unless i.e. the patcher supports updating them as well) causing it to mismatch the new contents of the user data in any modified sectors, causing any changes to not take effect or invalidate the disc image when it is burned to a disc and used on real hardware. Usually this isn't a problem since almost all CD burning software writes updated EDC/ECC to burned discs on the fly based on the data in the user data portion of the sector. Most emulators also ignore the EDC/ECC data in sectors by design as an optimization/feature. 
+
+* [IMGBurn](https://www.imgburn.com/) always writes updated EDC/ECC data, and there isn't a way to disable that behavior. 
+
+* [CDRDAO](https://github.com/cdrdao/cdrdao) always writes updated EDC/ECC data when using the default `generic-mmc` driver. It is possible however specify the `generic-mmc-raw` be used instead which **does not modify EDC/ECC data and leaves it as is**. 
+
+* [CloneCD](https://www.redfox.bz/en/clonecd.html) always writes updated EDC/ECC data **unless you use the RAW writing mode**. Writing updated EDC data to disc is usually what you want, that way the correct matching EDC/ECC data correlates to any modification to the user data of sectors found in a disc image. 
+
+But what if you want to edit user data of sectors in a data track of a CD disc image and then write it raw? That is exactly what I want to do to defeats the EDC-based anti-piracy protection measure found in almost all of the [Dance Dance Revolution PSX games](https://alex-free.github.io/aprip#edc).
 
 ## PSX EDC Anti-Piracy Protection
 
-The idea of EDC/ECC based additional anti-piracy protection is a brilliantly flawed one. See, Sony's tools to generate disc images back in the day were [buggy](http://www.psxdev.net/forum/viewtopic.php?t=1475). One such bug appears to be that the [reserved sectors 12-15](http://problemkaputt.de/psx-spx.htm#cdromisovolumedescriptors), which are zero filled in the user data portion of the sector, _also_ **have an EDC checksum of zero**. The correct checksum for a zero-filled user data sector _should be_ `3F 13 B0 BE`, _but it isn't_. It's `00 00 00 00` like the rest of the sector besides the sync data. This actually doesn't matter in practice, so the bug went unoticed and the technically invalid sector 12-15s shipped on real licensed PSX CD-ROMs. This apparently got fixed eventually in some newer version of the `cdgen` Sony tool that created disc images.
+The idea of EDC/ECC based additional anti-piracy protection is a brilliantly flawed one. See, Sony's tools to generate disc images back in the day were [buggy](http://www.psxdev.net/forum/viewtopic.php?t=1475). One such bug appears to be that the [reserved sectors 12-15](http://problemkaputt.de/psx-spx.htm#cdromisovolumedescriptors), which are zero filled in the user data portion of the sector, _also_ **have an EDC checksum of zero**. The correct checksum for a zero-filled user data sector _should be_ `3F 13 B0 BE`, _but it isn't_. It's `00 00 00 00` like the rest of the sector besides the sync data. This actually doesn't matter in practice, so the bug went un-noticed and the technically invalid sector 12-15s shipped on real licensed PSX CD-ROMs.
 
 Someone working on the Dance Dance Revolution PSX games noticed this strange behavior and figured out that it could be exploited as an additional anti-piracy protection measure. If the real licensed PSX CD-ROM discs were shipped with an EDC checksum of zero in sector 12-15, then when someone went to rip the real licensed PSX CD-ROM disc and then burn it back to a CD-R, the EDC checksum in sector 12-15 would no longer be `00 00 00 00`, it would be the expected `3F 13 B0 BE`. [Game code](https://github.com/socram8888/tonyhax/issues/121#issuecomment-1341381549) can read the EDC checksum on the disc at sector 12, and a routine could then lock up the game if the EDC data is non-zero to deter piracy.
 
@@ -131,12 +141,10 @@ Breakdown what each of these arguments to CDRDAO do:
 
 *   `--eject` will automatically eject the disc immediately after a successful burn.
 
-## License
-
-EDCRE is modified [CDRDAO](https://github.com/cdrdao/cdrdao) source code, which is licensed under the GPLv2 license. Please see the file `license.txt` in each release for full info.
-
 ## Credits
 
 *   [CDRDAO](https://github.com/cdrdao/cdrdao) source code.
+
 *   [Socram8888](https://github.com/socram8888) for providing info on [how EDC Protected games detect a corrected EDC checksum](https://github.com/socram8888/tonyhax/issues/121#issuecomment-1341365357).
+
 *   [MottZilla](https://github.com/mottzilla) for coming up with the workaround idea: "Just don't update those sectors" lol.

--- a/variables.mk
+++ b/variables.mk
@@ -13,8 +13,11 @@ VERSION=1.0.9
 RELEASE_FILES=*.md
 # OPTIONAL: files included only in the Linux portable releases (.zip).
 LINUX_SPECIFIC_RELEASE_FILES=
+# OPTIONAL: files included only in the MacOS portable releases (.zip).
+MACOS_SPECIFIC_RELEASE_FILES=
 # OPTIONAL: files included only in the Windows portable releases (.zip).
 WINDOWS_SPECIFIC_RELEASE_FILES=
+
 
 # All dependencies required to build the software, EzRe style. These deps allow for:
 # C and C++ programs.
@@ -31,17 +34,9 @@ BUILD_DEPENDS_DNF=gcc g++ libstdc++-static.i686 glibc-static.i686 libstdc++-stat
 # REQUIRED: Appended to end of release file name. Release file format is $(RELEASE_BASE_NAME)-$(VERSION)-$(RELEASE_NAME_SUFFIX).
 LINUX_I386_RELEASE_NAME_SUFFIX=linux-i386-static
 LINUX_X86_64_RELEASE_NAME_SUFFIX=linux-x86_64-static
+MACOS_RELEASE_NAME_SUFFIX=macos
 WINDOWS_I686_RELEASE_NAME_SUFFIX=windows-i686-static
 WINDOWS_X86_64_RELEASE_NAME_SUFFIX=windows-x86_64-static
-
-# REQUIRED: Linux Compiler For i386 and x86_64.
-LINUX_COMPILER=g++
-# REQUIRED: Windows Cross Compiler For i686.
-WINDOWS_I686_COMPILER=i686-w64-mingw32-g++
-# REQUIRED: Windows Cross Compiler For x86_64.
-WINDOWS_X86_64_COMPILER=x86_64-w64-mingw32-g++
-# REQUIRED: Host system compiler.
-COMPILER=$(LINUX_COMPILER)
 
 # REQUIRED Linux AR command (for building libraries with EZRE used by the target program).
 LINUX_AR=ar
@@ -62,9 +57,9 @@ WINDOWS_X86_64_STRIP=x86_64-w64-mingw32-strip
 STRIP=$(LINUX_STRIP)
 
 # REQUIRED: compiler flags used to compile $(SOURCE_FILES). To make a C/C++ program portable, you probably at least want `-static` as shown below. I like using `-Wall -Wextra -Werror -pedantic -static` or some variation.
-COMPILER_FLAGS=-Wall -Wextra -Werror -pedantic -static
+COMPILER_FLAGS=-Wall -Wextra -Werror -pedantic
 # REQUIRED: compiler flag appended to $(COMPILER_FLAGS) to compile $(SOURCE_FILES) for Linux x86 builds. This tells GCC to build i386 code on an x86_64 system.
-COMPILER_FLAGS_LINUX_I386=-m32
+COMPILER_FLAGS_LINUX_I386=-static -m32
 # OPTIONAL: You may compile a library with different CFLAGS set here. (i.e. `-Wall -Wextra -Werror -pedantic -Wno-unused-function`)
 COMPILER_FLAGS_LIB=
 # REQUIRED: set to `YES` to build additional libraries (must edit Makefile with relevant info). By default this is set to `NO`.

--- a/variables.mk
+++ b/variables.mk
@@ -1,44 +1,73 @@
-# Variables of EzRe GNUMakefile for Linux/Windows by Alex Free https://github.com/alex-free/ezre
+# EzRe GNUMakefile Variables for Linux/Windows. See https://github.com/alex-free/ezre for more info.
 
-# Basename of all release files (.zip, .deb)
+# REQUIRED: executable name in release (.exe file extension is appended for Windows builds). I.e. hello.
+PROGRAM=edcre
+# REQUIRED: source files to be compiled into $(PROGRAM) target. Can use wildcard (i.e. *.c, *.cpp, etc) or specify files specifically. These files are looked for in the same directory that the EZRE `Makefile` and `variables.mk` files are in (relative).
+SOURCE_FILES=edcre.cc
+# REQUIRED: Basename of all release files (.zip, .deb). I.e. hello-world.
 RELEASE_BASE_NAME=edcre
-# Version number, passed as 'VERSION' string to $(SOURCE_FILES)
-VERSION=v1.0.8
-# Appeneded to end of release file name
+# REQUIRED: Version number, passed as 'VERSION' string to $(SOURCE_FILES). I.e. v1.0.
+VERSION=1.0.9
+
+# OPTIONAL: additional files included in all portable zip releases. I.e. readme.md.
+RELEASE_FILES=*.md
+# OPTIONAL: files included only in the Linux portable releases (.zip).
+LINUX_SPECIFIC_RELEASE_FILES=
+# OPTIONAL: files included only in the Windows portable releases (.zip).
+WINDOWS_SPECIFIC_RELEASE_FILES=
+
+# All dependencies required to build the software, EzRe style. These deps allow for:
+# C and C++ programs.
+# RPM and DEB package creation for Linux.
+# Windows i686 and x86_64 builds.
+# Linux i386 and x86_64 builds.
+# Zip releases for all builds.
+# EZRE uses the make deps rule to find either dnf and apt, and installs the below deps accordingly.
+# For APT:
+BUILD_DEPENDS_APT=build-essential g++-multilib gcc-multilib mingw-w64-tools g++-mingw-w64 zip dpkg-dev rpm
+# For DNF:
+BUILD_DEPENDS_DNF=gcc g++ libstdc++-static.i686 glibc-static.i686 libstdc++-static.x86_64 mingw64-gcc mingw32-gcc mingw32-gcc-c++ mingw64-gcc-c++ zip dpkg-dev rpmdevtools
+
+# REQUIRED: Appended to end of release file name. Release file format is $(RELEASE_BASE_NAME)-$(VERSION)-$(RELEASE_NAME_SUFFIX).
 LINUX_I386_RELEASE_NAME_SUFFIX=linux-i386-static
 LINUX_X86_64_RELEASE_NAME_SUFFIX=linux-x86_64-static
 WINDOWS_I686_RELEASE_NAME_SUFFIX=windows-i686-static
 WINDOWS_X86_64_RELEASE_NAME_SUFFIX=windows-x86_64-static
-# Release file format is $(RELEASE_BASE_NAME)-$(VERSION)-$(RELEASE_NAME_SUFFIX)
 
-# Files included in all portable releases (.zip)
-RELEASE_FILES=readme.md changelog.md license.md images
-# OPTIONAL: files included only in the Linux portable releases (.zip)
-LINUX_SPECIFIC_RELEASE_FILES=
-# OPTIONAL: files included only in the Windows portable releases (.zip)
-WINDOWS_SPECIFIC_RELEASE_FILES=
-
-# All dependencies required to build the software, to be installed when using deps-apt EzRe Makefile rule (For Debian/Ubuntu)
-BUILD_DEPENDS_APT=build-essential g++-multilib gcc-multilib mingw-w64-tools g++-mingw-w64 zip dpkg-dev
-# All dependencies required to build the software, to be installed when using deps-dnf EzRe Makefile rule (For Fedora/Red Hat)
-BUILD_DEPENDS_DNF=gcc g++ libstdc++-static.i686 glibc-static.i686 libstdc++-static.x86_64 mingw64-gcc mingw32-gcc mingw32-gcc-c++ mingw64-gcc-c++ zip
-
-# Executable name in release (.exe file extension is appended for Windows builds)
-PROGRAM=edcre
-# Source files to be compiled into $(PROGRAM) target
-SOURCE_FILES=edcre.cc
-# Compiler flags used to compile $(SOURCE_FILES)
-COMPILER_FLAGS=-Wall -Wextra -Werror -pedantic -Ofast
-# Compiler flag appended to $(COMPILER_FLAGS) to compile $(SOURCE_FILES) for Linux x86 builds
-COMPILER_FLAGS_LINUX_X86=-m32
-# Create builds in this directory relative to $(SOURCE_FILES)
-BUILD_DIR=build
-
-# Linux Compiler For i386 and x86_64
+# REQUIRED: Linux Compiler For i386 and x86_64.
 LINUX_COMPILER=g++
-# Windows Cross Compiler For i686
-WINDOWS_X86_COMPILER=i686-w64-mingw32-g++
-# Windows Cross Compiler For x86_64
+# REQUIRED: Windows Cross Compiler For i686.
+WINDOWS_I686_COMPILER=i686-w64-mingw32-g++
+# REQUIRED: Windows Cross Compiler For x86_64.
 WINDOWS_X86_64_COMPILER=x86_64-w64-mingw32-g++
-# Host system compiler
+# REQUIRED: Host system compiler.
 COMPILER=$(LINUX_COMPILER)
+
+# REQUIRED Linux AR command (for building libraries with EZRE used by the target program).
+LINUX_AR=ar
+# REQUIRED: Windows i686 AR command (for building libraries with EZRE used by the target program).
+WINDOWS_I686_AR=i686-w64-mingw32-ar
+# REQUIRED: Windows x86_64 AR command (for building libraries with EZRE used by the target program).
+WINDOWS_X86_64_AR=x86_64-w64-mingw32-ar
+# REQUIRED: Host system ar
+AR=$(LINUX_AR)
+
+# REQUIRED: Linux strip command.
+LINUX_STRIP=strip
+# REQUIRED: Windows i686 strip command (for building libraries with EZRE used by the target program).
+WINDOWS_I686_STRIP=i686-w64-mingw32-strip
+# REQUIRED: Windows x86_64 strip command (for building libraries with EZRE used by the target program).
+WINDOWS_X86_64_STRIP=x86_64-w64-mingw32-strip
+# REQUIRED: Host system strip.
+STRIP=$(LINUX_STRIP)
+
+# REQUIRED: compiler flags used to compile $(SOURCE_FILES). To make a C/C++ program portable, you probably at least want `-static` as shown below. I like using `-Wall -Wextra -Werror -pedantic -static` or some variation.
+COMPILER_FLAGS=-Wall -Wextra -Werror -pedantic -static
+# REQUIRED: compiler flag appended to $(COMPILER_FLAGS) to compile $(SOURCE_FILES) for Linux x86 builds. This tells GCC to build i386 code on an x86_64 system.
+COMPILER_FLAGS_LINUX_I386=-m32
+# OPTIONAL: You may compile a library with different CFLAGS set here. (i.e. `-Wall -Wextra -Werror -pedantic -Wno-unused-function`)
+COMPILER_FLAGS_LIB=
+# REQUIRED: set to `YES` to build additional libraries (must edit Makefile with relevant info). By default this is set to `NO`.
+BUILD_LIB=NO
+# REQUIRED: create builds in this directory relative to $(SOURCE_FILES). THIS DIRECTORY WILL BE DELETED WHEN EXECUTING `make clean-build` SO BE EXTREMELY CAREFUL WITH WHAT YOU SET THIS TOO.
+BUILD_DIR=build


### PR DESCRIPTION
Hi, thanks for your work on this tool.

I had to use it lately and noticed it wouldn't build straight away on MacOS. The changes to make it build (and it runs perfectly!) were minimal in the end.

I don't think my changes broke anything, but I don't have platforms to test Linux/Windows, so just in case, here are my changes:
- MacOS uses `clang` instead of `g++`, so I replaced `$(COMPILER)` with `$(CXX)` to always use the default C++ compiler and removed the `$(COMPILER_*)` variables. This should be platform-agnostic and I know `CXX` works fine on Linux, but I have never compiled on Windows, so no idea.
- It seems the `-static` argument doesn't work correctly with clang so I moved it to `$(COMPILER_FLAGS_LINUX_I386)`.

I added rules for `macos` and `macos-release`, these two shouldn't impact anything else.

Thanks again for you hard work